### PR TITLE
Add more Filament types and order type and color

### DIFF
--- a/firmware/bambu.h
+++ b/firmware/bambu.h
@@ -10,6 +10,8 @@ namespace bambulabs
     const std::unordered_map<std::string, std::string> filament_mappings = {
         {"TPU", "GFU99"},
         {"PLA", "GFL99"},
+        {"PLA High Speed", "GFL95"},
+        {"PLA Silk", "GFL96"},
         {"PETG", "GFG99"},
         {"PET-CF", "GFG99"},
         {"ASA", "GFB98"},
@@ -19,16 +21,31 @@ namespace bambulabs
         {"PA-CF", "GFN98"},
         {"PLA-CF", "GFL98"},
         {"PVA", "GFS99"},
+        {"BVOH", "GFS97"},
+        {"EVA", "GFR99"},
+        {"HIPS", "GFS98"},
+        {"PC", "GFC99"},
+        {"PCTG", "GFG97"},
+        {"PE", "GFP99"},
+        {"PE-CF", "GFP98"},
+        {"PHA", "GFR98"},
+        {"PP", "GFP97"},
+        {"PP-CF", "GFP96"},
+        {"PP-GF", "GFP95"},
+        {"PPA-CF", "GFN97"},
+        {"PPA-GF", "GFN96"},
         {"Support", "GFS00"}};
 
     // Special cases for brand-specific codes
     const std::unordered_map<std::string, std::unordered_map<std::string, std::string>> brand_specific_codes = {
         {"PLA", {{"Bambu", "GFA00"}, {"PolyTerra", "GFL01"}, {"PolyLite", "GFL00"}}},
         {"TPU", {{"Bambu", "GFU01"}}},
-        {"ABS", {{"Bambu", "GFB00"}}},
+        {"ABS", {{"Bambu", "GFB00"}, {"PolyLite", "GFB60"}}},
+        {"ASA", {{"Bambu", "GFB01"}, {"PolyLite", "GFB61"}}},
         {"PC", {{"Bambu", "GFC00"}}},
         {"PA-CF", {{"Bambu", "GFN03"}}},
-        {"PET-CF", {{"Bambu", "GFT00"}}}};
+        {"PET-CF", {{"Bambu", "GFT00"}}},
+        {"PETG", {{"Bambu", "GFG00"}, {"PolyLite", "GFG60"}}}};
 
     // Function with two parameters
     inline std::string get_bambu_code(const std::string &type, const std::string &brand = "")

--- a/firmware/conf.d/filament.yaml
+++ b/firmware/conf.d/filament.yaml
@@ -12,14 +12,30 @@ select:
     web_server:
       sorting_group_id: sorting_group_filament_settings
     options:
-      - PLA
-      - PETG
-      - TPU
       - ABS
-      - PLA-CF
+      - ASA
+      - BVOH
+      - EVA
+      - HIPS
+      - PA
       - PA-CF
+      - PC
+      - PCTG
+      - PE
+      - PE-CF
+      - PETG
+      - PET-CF
+      - PLA
+      - PLA High Speed
+      - PLA Silk
+      - PLA-CF
+      - PP
+      - PP-CF
+      - PP-GF
+      - PPA-CF
+      - PPA-GF
       - PVA
-      - PET-CF #TODO: double check it is PET-CF and not PETCF as I think I've seen both in wolfwithsword code
+      - TPU
     on_value:
       then:
         - script.execute: generate_filament_brand_code
@@ -74,29 +90,29 @@ select:
       sorting_group_id: sorting_group_filament_settings
     optimistic: true
     options:
-      - "white"
-      - "yellow"
+      - "beige"
+      - "black"
+      - "blue"
+      - "dark_blue"
+      - "ice_blue"
+      - "brown"
+      - "dark_brown"
+      - "cyan"
+      - "desert_tan"
       - "grass_green"
       - "bambu_green"
       - "missletoe_green"
-      - "dark_blue"
       - "glow_green"
-      - "ice_blue"
-      - "cyan"
-      - "blue"
-      - "iris_purple"
-      - "magenta"
-      - "sakura_pink"
-      - "pink"
-      - "red"
-      - "dark_brown"
-      - "orange"
-      - "beige"
-      - "desert_tan"
-      - "brown"
       - "ash_grey"
       - "grey"
-      - "black"
+      - "magenta"
+      - "orange"
+      - "pink"
+      - "sakura_pink"
+      - "iris_purple"
+      - "red"
+      - "white"
+      - "yellow"
       - "Unknown"
     on_value:
       then:


### PR DESCRIPTION
- Added all "Generic" filament types that Bambu Studio supports with matching codes
- Sorted the colors and filament types alphabetically