### PR TITLE
Add ESP32 WROOM support

### DIFF
--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -72,3 +72,6 @@ lolin_s3_mini:
 devkit:
 	esphome \
 		run esp32-s3-devkitc-1.yaml --device $(USB_ADDRESS)
+esp32-32d:
+	esphome \
+		run esp32-32d.yaml --device $(USB_ADDRESS)

--- a/firmware/conf.d/pn532_rfid-solo.yaml
+++ b/firmware/conf.d/pn532_rfid-solo.yaml
@@ -16,8 +16,8 @@ binary_sensor:
   web_server:
     sorting_group_id: sorting_group_rfid
 spi:
-# On esp32-s3 SPI2 a can support 6 devices, whereas only 3 on bus SPI3
-- id: SPI2
+# On esp32-s3 SPI1 a can support 6 devices, whereas only 3 on bus SPI3
+- id: ${spi2_type}
   clk_pin: ${spi2_clk_pin} # SCK
   miso_pin: ${spi2_miso_pin} # MO/SDA/TX (MISO)
   mosi_pin: ${spi2_mosi_pin} # M (MOSI)

--- a/firmware/esp32-32d.yaml
+++ b/firmware/esp32-32d.yaml
@@ -1,0 +1,24 @@
+esp32:
+  board: esp32dev
+
+substitutions:
+  hide_ams_sensors: 'false'
+  led_pin: GPIO21
+  spi2_type: any
+  spi2_clk_pin: GPIO14
+  spi2_miso_pin: GPIO12
+  spi2_mosi_pin: GPIO13
+
+  rfid0_spi_interface: any
+  rfid0_ss_pin: GPIO15
+
+packages: 
+  openspool-mini: !include openspool-mini.yaml
+  #improv-serial: !include conf.d/improv-serial.yaml
+  #improv-bluetooth: !include conf.d/improv-bluetooth.yaml
+  #led-internal: !include conf.d/led-internal.yaml
+  extra: !include conf.d/extra.yaml
+
+dashboard_import:
+  package_import_url: github://spuder/openspool/firmware/esp32-32d.yaml@main
+  import_full_config: false


### PR DESCRIPTION
I've managed to add support for the base ESP32 Models (ESP32 Wroom).
The project compiles perfectly fine and the dashboard, the tag reading and writing works perfectly.