### PR TITLE
Update to esphome 2025.6.0

### DIFF
--- a/firmware/common.yaml
+++ b/firmware/common.yaml
@@ -7,7 +7,7 @@ esphome:
   project:
     name: spuder.openspool
     version: ${version}
-  min_version: 2024.11.0
+  min_version: 2025.6.0
   platformio_options:
     build_unflags: -std=gnu++11
     build_flags:

--- a/firmware/common.yaml
+++ b/firmware/common.yaml
@@ -1,4 +1,6 @@
 ---
+preferences:
+  flash_write_interval: 3sec
 substitutions:
   name: openspool
 esphome:

--- a/firmware/common.yaml
+++ b/firmware/common.yaml
@@ -78,9 +78,10 @@ esphome:
 esp32:
   framework:
     type: esp-idf
-    version: 5.3.1
-    platform_version: 6.9.0 # https://github.com/platformio/platform-espressif32/releases/
-    sdkconfig_options: 
+    # Let esphome handle the versions
+    #version: 5.3.2
+    #platform_version: 53.03.13 # https://github.com/pioarduino/platform-espressif32/releases
+    sdkconfig_options:
       CONFIG_MBEDTLS_HKDF_C: y # Needed for bambu KDF
       CONFIG_MBEDTLS_MD_C: y   # Needed for bambu KDF
     # version: recommended

--- a/firmware/conf.d/led-external.yaml
+++ b/firmware/conf.d/led-external.yaml
@@ -10,7 +10,6 @@ light:
   num_leds: ${led_count}
   rgb_order: GRB
   chipset: WS2812
-  rmt_channel: 0
   default_transition_length: 0.4s
   restore_mode: RESTORE_DEFAULT_ON
   entity_category: diagnostic

--- a/firmware/conf.d/led-internal.yaml
+++ b/firmware/conf.d/led-internal.yaml
@@ -8,6 +8,7 @@ light:
   chipset: WS2812
   rgb_order: GRB
   num_leds: 1
+  rmt_symbols: 48
   entity_category: diagnostic
   restore_mode: ALWAYS_OFF
   icon: mdi:led-strip

--- a/firmware/conf.d/led-internal.yaml
+++ b/firmware/conf.d/led-internal.yaml
@@ -6,7 +6,6 @@ light:
   state_topic:
   pin: ${neopixel_pin}
   chipset: WS2812
-  rmt_channel: 1
   rgb_order: GRB
   num_leds: 1
   entity_category: diagnostic


### PR DESCRIPTION
This PR makes sure that we can compile OpenSpool with ESPHome 2025.6.0
2025.6.0 comes with some nice updates like ESP-IDF 5.3.2 that have official support with ESP32 S3 and some speed and size-optimizations.
More info can be found here: https://esphome.io/changelog/2025.6.0.html#esphome-2025-6-0-18th-june-2025

I have tried compiling and uploading esp32-s3-devkitc-1.yaml with the updated code without any problems.
I have also added the flash_write_interval with a 3 second interval.
In eariler esphome versions the values would get saved immediatly on change. Without flash_write_interval components with `restore_value: true` would only see its values stored once ever minute. I felts 3 seconds was a good middlepoint of fast saving and not spamming the flash. Thoughts?